### PR TITLE
Add test script and Next.js configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,1 @@
+export { default, metadata } from './(site)/layout';

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "echo \"No tests yet\""
   },
   "dependencies": {
     "next": "^14.2.5",
@@ -18,9 +19,12 @@
     "clsx": "^2.1.1"
   },
   "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/node": "^20.11.30",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "eslint": "^8.57.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -12,8 +16,26 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
-    "paths": {"@/": ["./"]}
+    "paths": {
+      "@/": [
+        "./"
+      ]
+    },
+    "incremental": true,
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "./**/*.ts", "./**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "./**/*.ts",
+    "./**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add top-level layout re-export for Next.js app directory
- configure ESLint with Next's core web vitals rules
- add placeholder test script and TypeScript/ESLint dev dependencies

## Testing
- `npm test`
- `npm run lint` *(fails: Your project has an older version of ESLint installed. Please upgrade to ESLint version 7 or above)*
- `npm run build` *(fails: ENETUNREACH fetch failed during lockfile patching)*

------
https://chatgpt.com/codex/tasks/task_e_68a562955b00832fab581324a50cdd0d