### PR TITLE
Fix root path alias configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,8 @@
     "jsx": "preserve",
     "baseUrl": ".",
     "paths": {
-      "@/": [
-        "./"
+      "@/*": [
+        "./*"
       ]
     },
     "incremental": true,


### PR DESCRIPTION
## Summary
- correct TypeScript path mapping so `@/*` resolves to root

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found; npm install 403)*
- `npm run build` *(fails: next: not found; npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a573c5ad08832f8fc787cc9657fed8