### PR TITLE
Fix build errors with ESLint config and search params

### DIFF
--- a/app/(site)/pedago/page.tsx
+++ b/app/(site)/pedago/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { Suspense } from "react";
 import Modal from "@/components/Modal";
 import { pedaproject } from "@/lib/content";
 import Slideshow from "@/components/Slideshow";
@@ -31,7 +31,9 @@ export default function PedagoPage() {
           </Card>
         ))}
       </section>
-      <Modal />
+      <Suspense fallback={null}>
+        <Modal />
+      </Suspense>
     </main>
   );
 }

--- a/app/(site)/tech/page.tsx
+++ b/app/(site)/tech/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { Suspense } from "react";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { Badge } from "@/components/ui/Badge";
@@ -43,7 +43,9 @@ export default function TechPage() {
           </Card>
         ))}
       </section>
-      <Modal />
+      <Suspense fallback={null}>
+        <Modal />
+      </Suspense>
     </main>
   );
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4",
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,12 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./styles/**/*.{css}", "./lib/**/*.{ts,tsx}"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./styles/**/*.css",
+    "./lib/**/*.{ts,tsx}"
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- add missing `eslint-config-next` dev dependency
- update Tailwind CSS glob pattern
- wrap modal usage in `<Suspense>` to satisfy `useSearchParams`

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test`
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a6c85994832f9966328f81e538de