### PR TITLE
fix: prevent console text overflow and slow typing effect

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -27,7 +27,7 @@ export default function Terminal() {
         }, 800);
       }
     }
-    timer = setInterval(tick, 25);
+    timer = setInterval(tick, 40);
     return () => clearInterval(timer);
   }, [i]);
 
@@ -36,7 +36,7 @@ export default function Terminal() {
       aria-live="polite"
       className="fixed right-4 bottom-4 w-[420px] max-w-[calc(100%-1rem)] text-green-400 brutal-card bg-black/90 text-sm"
     >
-      <div className="whitespace-pre border-r-4 pr-1">{text}</div>
+      <div className="whitespace-pre-wrap break-words border-r-4 pr-1">{text}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- slow down typing effect in Terminal
- wrap terminal text to stay inside the console

## Testing
- `npm test`
- `npm run lint` *(fails: next not found; dependency installation blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aa1ca69c832f987e519eb8ed77d6