### PR TITLE
Update terminal intro and availability colors

### DIFF
--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -2,12 +2,13 @@
 import React from "react";
 
 const LINES = [
-  "> souphiane --skills --format=json",
-  '{\n  "tech": ["Angular","Node","MongoDB","PHP","SQL"],\n  "forts": ["Analyser","Améliorer","Solutionner","Présenter"],\n  "disponibilité": ["🟢 Freelance","🟢 CDI"]\n}',
+  "Souphiane JENDER",
+  "Ingénieur Pédagogique",
+  "Chef de projet",
+  "Déploiement de solution numériques sur-mesure",
+  '{\n  "tech": ["Angular","Node","MongoDB","PHP","SQL"],\n  "forts": ["Analyser","Améliorer","Solutionner","Présenter"],\n  "disponibilité": ["🟢 Freelance","🟠 CDI"]\n}',
   "> portfolio --version",
-  "v2.3.1 - Brutalist Edition",
-  "> adoption --stats --last=12w",
-  '{ "usage": "↗", "satisfaction": "4.6/5", "incidents": "↓ 37%" }'
+  "v2.3.1 - Brutalist Edition"
 ];
 
 export default function Terminal() {


### PR DESCRIPTION
## Summary
- Replace terminal's opening command with a multi-line intro highlighting roles and mission
- Tweak availability display to show orange for CDI and keep green for freelance
- Remove end-of-terminal consultation statistics

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a5b4a6dd34832f9c4aaa405e2100f8