### PR TITLE
feat: add monochrome accessibility toggle

### DIFF
--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -14,7 +14,7 @@ export default function SiteLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="fr">
       <body className={clsx("min-h-screen")}>
-        <div className="fixed bottom-4 right-4 z-50">
+        <div className="fixed bottom-4 right-4 z-[100] pointer-events-auto">
           <A11yMonoToggle />
         </div>
         {children}

--- a/components/A11yMonoToggle.tsx
+++ b/components/A11yMonoToggle.tsx
@@ -8,16 +8,19 @@ export default function A11yMonoToggle() {
     const saved = localStorage.getItem("a11y-mono") === "1";
     setOn(saved);
     document.body.setAttribute("data-a11y", saved ? "mono" : "");
+    document.documentElement.classList.toggle("a11y-mono", saved);
   }, []);
 
   return (
     <button
+      type="button"
       aria-pressed={on}
       onClick={() => {
         const next = !on;
         setOn(next);
         document.body.setAttribute("data-a11y", next ? "mono" : "");
         localStorage.setItem("a11y-mono", next ? "1" : "0");
+        document.documentElement.classList.toggle("a11y-mono", next);
       }}
       className="text-xs px-3 py-1 border rounded"
       title="Activer le mode N&B"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -129,3 +129,11 @@ html,body{
 [data-a11y="mono"] .prose {
   color: var(--text);
 }
+
+/* Forcer le texte en N&B sur la home quand le mode est activé */
+html.a11y-mono .text-tech-primary,
+html.a11y-mono .text-edu-primary,
+html.a11y-mono .text-proj-primary,
+html.a11y-mono .text-contact-primary {
+  color: var(--text) !important;
+}


### PR DESCRIPTION
## Summary
- add client-side toggle component to switch monochrome accessibility theme
- style monochrome accessibility mode variables and focus outline
- mount toggle in site layout for persistent site-wide access

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found; installation blocked with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ecca3850832f97dabbd2bf694870