### PR TITLE
feat: add persistent home navigation

### DIFF
--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -4,7 +4,7 @@ import { SectionHeader } from "@/components/SectionHeader";
 export default function ContactPage() {
   return (
     <section className="p-6 md:p-10 max-w-3xl mx-auto space-y-4">
-      <SectionHeader title="Contact direct" />
+      <SectionHeader section="Contact" title="Contact direct" />
       <p>
         Email: <a className="link-neon" href="mailto:sjender@exemple.com">sjender@exemple.com</a>
       </p>

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -1,6 +1,8 @@
 import "@/styles/globals.css";
 import type { Metadata } from "next";
 import { clsx } from "clsx";
+import HomePortal from "@/components/HomePortal";
+import FooterHomeLink from "@/components/FooterHomeLink";
 
 export const metadata: Metadata = {
   title: "Souphiane Jender — Portfolio (Tech × Pédago)",
@@ -12,7 +14,11 @@ export const metadata: Metadata = {
 export default function SiteLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="fr">
-      <body className={clsx("min-h-screen")}>{children}</body>
+      <body className={clsx("min-h-screen")}> 
+        <HomePortal />
+        {children}
+        <FooterHomeLink />
+      </body>
     </html>
   );
 }

--- a/app/(site)/pedago/page.tsx
+++ b/app/(site)/pedago/page.tsx
@@ -10,7 +10,7 @@ import { SectionHeader } from "@/components/SectionHeader";
 export default function PedagoPage() {
   return (
     <section className="p-6 md:p-10 max-w-6xl mx-auto space-y-6">
-      <SectionHeader kicker="Pédagogie" title="Pédagogie 4.0" />
+      <SectionHeader section="Pédagogie" kicker="Pédagogie" title="Pédagogie 4.0" />
       <Slideshow skills={pedaproject.map((p) => ({ title: p.title, text: p.text, modalContent: p.modalContent }))} />
       <div className="grid grid-auto gap-5">
         {pedaproject.map((item) => (

--- a/app/(site)/proj/page.tsx
+++ b/app/(site)/proj/page.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { Card } from "@/components/ui/Card";
+import { SectionHeader } from "@/components/SectionHeader";
 
 export default function ProjPage() {
   return (
-    <main className="p-6 md:p-10 max-w-6xl mx-auto space-y-6">
-      <h2 className="text-3xl font-extrabold">Gestion de projets</h2>
+    <section className="p-6 md:p-10 max-w-6xl mx-auto space-y-6">
+      <SectionHeader section="Projets" title="Gestion de projets" />
       <div className="grid grid-auto gap-4">
         <Card>
           <h3 className="text-xl font-extrabold">Cadre POC → REX</h3>
@@ -16,6 +17,6 @@ export default function ProjPage() {
           </ol>
         </Card>
       </div>
-    </main>
+    </section>
   );
 }

--- a/app/(site)/tech/page.tsx
+++ b/app/(site)/tech/page.tsx
@@ -12,6 +12,7 @@ export default function TechPage() {
   return (
     <section className="p-6 md:p-10 max-w-6xl mx-auto space-y-6">
       <SectionHeader
+        section="Tech"
         kicker="Tech"
         title="Engineering Tech"
         subtitle="Stack: Angular · Node · MongoDB · PHP · SQL · SSO"

--- a/components/FooterHomeLink.tsx
+++ b/components/FooterHomeLink.tsx
@@ -1,0 +1,15 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function FooterHomeLink() {
+  const pathname = usePathname();
+  if (pathname === "/") return null;
+  return (
+    <footer className="p-6 text-center text-sm">
+      <Link href="/" className="hover:underline">
+        ← Accueil
+      </Link>
+    </footer>
+  );
+}

--- a/components/HomePortal.tsx
+++ b/components/HomePortal.tsx
@@ -1,0 +1,51 @@
+"use client";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import clsx from "clsx";
+
+export default function HomePortal() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const lastKey = useRef<string>();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === "g") {
+        lastKey.current = "g";
+      } else if (lastKey.current === "g" && e.key.toLowerCase() === "h") {
+        router.push("/");
+        lastKey.current = undefined;
+      } else {
+        lastKey.current = undefined;
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [router]);
+
+  if (pathname === "/") return null;
+
+  return (
+    <Link
+      href="/"
+      aria-label="Aller à l’accueil"
+      aria-description="Raccourci g puis h"
+      title="Revenir à la page d’accueil"
+      className={clsx(
+        "fixed top-4 left-4 z-40 w-11 h-11 flex items-center justify-center text-xs font-bold",
+        "bg-surface/60 text-text backdrop-blur",
+        "shadow-[0_0_.5rem_var(--pri)] hover:shadow-[0_0_1rem_var(--pri)]",
+        "rounded-neon transition-all motion-reduce:transition-none",
+        "hover:-translate-y-0.5 motion-reduce:hover:translate-y-0",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--acc)] focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+      )}
+      style={{
+        clipPath: "polygon(25% 6%, 75% 6%, 94% 50%, 75% 94%, 25% 94%, 6% 50%)",
+      }}
+    >
+      Accueil
+    </Link>
+  );
+}
+

--- a/components/SectionHeader.tsx
+++ b/components/SectionHeader.tsx
@@ -1,10 +1,21 @@
+import Link from "next/link";
+
 export function SectionHeader({
   kicker,
   title,
   subtitle,
-}: { kicker?: string; title: string; subtitle?: string }) {
+  section,
+}: { kicker?: string; title: string; subtitle?: string; section?: string }) {
   return (
     <header className="mb-6">
+      {section && (
+        <nav className="mb-1 text-sm" aria-label="Fil d'Ariane">
+          <Link href="/" className="text-[color:var(--acc)] hover:underline">
+            Accueil
+          </Link>
+          <span className="hidden md:inline"> / {section}</span>
+        </nav>
+      )}
       {kicker && <div className="uppercase tracking-widest text-[color:var(--acc)] text-xs">{kicker}</div>}
       <h1 className="text-3xl md:text-4xl font-extrabold text-text drop-shadow-[0_0_.6rem_var(--pri)]">{title}</h1>
       {subtitle && <p className="text-muted mt-2 max-w-prose">{subtitle}</p>}


### PR DESCRIPTION
## Summary
- add floating HomePortal with theme-aware style and keyboard shortcut
- expose breadcrumb in SectionHeader and wire pages to it
- provide footer "← Accueil" fallback link

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a787b673e0832f8b6082187063f8cb